### PR TITLE
Add initial Python 3.x compatibility

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include chdkptp_module.diff
+include get_chdkptp.py
 graft chdkptp/vendor

--- a/chdkptp/lua.py
+++ b/chdkptp/lua.py
@@ -25,7 +25,7 @@ class LuaContext(object):
         inside of `pcall` and raises proper Exceptions.
     """
     def _raise_exception(self, errval):
-        if isinstance(errval, (basestring, numbers.Number)):
+        if isinstance(errval, (bytes, str, numbers.Number)):
             raise lupa.LuaError(errval)
         elif errval['etype'] == 'ptp':
             raise PTPError(errval)
@@ -85,7 +85,7 @@ class LuaContext(object):
         return self._rt.globals()
 
     def __init__(self):
-        self._rt = lupa.LuaRuntime(unpack_returned_tuples=True, encoding=None)
+        self._rt = lupa.LuaRuntime(unpack_returned_tuples=True, encoding='latin-1')
         if self.eval("type(jit) == 'table'"):
             raise RuntimeError("lupa must be linked against Lua, not LuaJIT.\n"
                                "Please install lupa with `--no-luajit`.")
@@ -146,9 +146,9 @@ LuaTable = type(global_lua.table())
 
 def parse_table(table):
     out = dict(table)
-    for key, val in out.iteritems():
+    for key, val in out.items():
         if isinstance(val, LuaTable):
             out[key] = parse_table(val)
-    if all(x.isdigit() for x in out.iterkeys()):
+    if all(x.isdigit() for x in out.keys()):
         out = tuple(out.values())
     return out

--- a/chdkptp/lua.py
+++ b/chdkptp/lua.py
@@ -2,7 +2,9 @@ import logging
 import numbers
 import os
 
-import lupa
+import lupa as _lupa
+with _lupa.allow_lua_module_loading():
+    import lupa.lua52 as lupa
 
 CHDKPTP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             'vendor', 'chdkptp')

--- a/chdkptp/util.py
+++ b/chdkptp/util.py
@@ -1,7 +1,14 @@
 import os
+import sys
 
 from chdkptp.lua import global_lua
 
+
+def str_to_bytes(x, enc='latin-1'):
+    if sys.version_info[0] > 2:
+        return x.encode(enc)
+    else:
+        return bytes(x)
 
 def iso_to_sv96(iso):
     return global_lua.globals.exposure.iso_to_sv96(iso)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@ class Mock(object):
 
     @classmethod
     def __getattr__(cls, name):
-        print "Getting mock: ", name
+        print("Getting mock: ", name)
         if name in ('__file__', '__path__'):
             return '/dev/null'
         elif name == 'eval':

--- a/get_chdkptp.py
+++ b/get_chdkptp.py
@@ -43,3 +43,9 @@ def build_static_lua(srcdir):
     if p.returncode != 0:
         raise RuntimeError("Error building static Lua")
     os.chdir(orig_path)
+
+
+def build_chdkptp(srcdir):
+    config_template = os.path.join(srcdir, 'config-sample-linux.mk')
+    shutil.copyfile(config_template, os.path.join(srcdir, 'config.mk'))
+    sub.check_call(['make', '-C', srcdir])

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import os
 
-from setuptools.command.build import build as BuildCommand
 from setuptools import setup
+try:
+    from setuptools.command.build import build as BuildCommand
+except ImportError:
+    from distutils.command.build import build as BuildCommand
 
 from get_chdkptp import (
     get_chdkptp_source, apply_patches, build_static_lua, build_chdkptp

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,29 @@
 import os
-import subprocess
 
-from setuptools.command.install import install as InstallCommand
+from setuptools.command.build import build as BuildCommand
 from setuptools import setup
 
-from get_chdkptp import get_chdkptp_source, apply_patches, build_static_lua
+from get_chdkptp import (
+    get_chdkptp_source, apply_patches, build_static_lua, build_chdkptp
+)
 
 PKG_ROOT = os.path.dirname(os.path.abspath(__file__))
 CHDKPTP_PATH = os.path.join(PKG_ROOT, 'chdkptp', 'vendor', 'chdkptp')
 CHDKPTP_PATCH = os.path.join(PKG_ROOT, 'chdkptp_module.diff')
 
 
-class CustomInstall(InstallCommand):
+class CustomBuild(BuildCommand):
+
     def run(self):
-        os.symlink(os.path.join(CHDKPTP_PATH, 'config-sample-linux.mk'),
-                   os.path.join(CHDKPTP_PATH, 'config.mk'))
-        subprocess.check_call(['make', '-C', CHDKPTP_PATH])
-        InstallCommand.run(self)
 
+        get_chdkptp_source(CHDKPTP_PATH)
+        apply_patches(CHDKPTP_PATH, CHDKPTP_PATCH)
 
-get_chdkptp_source(CHDKPTP_PATH)
-apply_patches(CHDKPTP_PATH, CHDKPTP_PATCH)
-build_static_lua(CHDKPTP_PATH)
+        build_static_lua(CHDKPTP_PATH)
+        build_chdkptp(CHDKPTP_PATH)
+
+        BuildCommand.run(self)
+
 
 setup(
     name='chdkptp.py',
@@ -32,10 +34,11 @@ setup(
     author_email="johannes.baiter@gmail.com",
     license='GPL',
     packages=['chdkptp'],
-    package_data={"chdkptp": ["vendor/chdkptp/chdkptp.so",
+    package_dir={"chdkptp": "chdkptp"},
+    package_data={"chdkptp": ["vendor/chdkptp/*.so",
                               "vendor/chdkptp/lua/*.lua"]},
     install_requires=[
         "lupa >= 1.1",
     ],
-    cmdclass={'install': CustomInstall}
+    cmdclass={'build': CustomBuild}
 )

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_data={"chdkptp": ["vendor/chdkptp/*.so",
                               "vendor/chdkptp/lua/*.lua"]},
     install_requires=[
-        "lupa >= 1.1",
+        "lupa >= 2.1",
     ],
     cmdclass={'build': CustomBuild}
 )

--- a/test.py
+++ b/test.py
@@ -10,45 +10,45 @@ logging.basicConfig(level=logging.DEBUG)
 tmp_dir = tempfile.mkdtemp()
 dev = chdkptp.ChdkDevice(chdkptp.list_devices()[0])
 
-print "Test files can be found under {0}".format(tmp_dir)
+print("Test files can be found under {0}".format(tmp_dir))
 
-print "Checking connectivity"
+print("Checking connectivity")
 assert dev.is_connected
 
-print "Checking mode switch"
+print("Checking mode switch")
 if dev.mode == 'record':
     dev.switch_mode('play')
     assert dev.mode == 'play'
 dev.switch_mode('record')
 assert dev.mode == 'record'
 
-print "Checking streaming JPEG capture"
-for i in xrange(5):
+print("Checking streaming JPEG capture")
+for i in range(5):
     fpath = os.path.join(tmp_dir, "stream_{0:02}.jpg".format(i))
     imgdata = dev.shoot()
     with open(fpath, 'wb') as fp:
         fp.write(imgdata)
 
-print "Checking streaming DNG capture"
-for i in xrange(5):
+print("Checking streaming DNG capture")
+for i in range(5):
     fpath = os.path.join(tmp_dir, "stream_{0:02}.dng".format(i))
     imgdata = dev.shoot(dng=True)
     with open(fpath, 'wb') as fp:
         fp.write(imgdata)
 
-print "Checking downloading JPEG capture"
-for i in xrange(5):
+print("Checking downloading JPEG capture")
+for i in range(5):
     fpath = os.path.join(tmp_dir, "download_{0:02}.jpg".format(i))
     imgdata = dev.shoot(stream=False, download_after=True, remove_after=True)
     with open(fpath, 'wb') as fp:
         fp.write(imgdata)
 
-print "Checking file upload"
+print("Checking file upload")
 with open('/tmp/test.txt', 'w') as fp:
     fp.write('test')
 dev.upload_file('/tmp/test.txt', 'A/')
 assert 'a/test.txt' in [x.lower() for x in dev.list_files()]
 
-print "Checking file removal"
+print("Checking file removal")
 dev.delete_files('A/test.txt')
 assert 'a/test.txt' not in [x.lower() for x in dev.list_files()]


### PR DESCRIPTION
This PR adds initial support for Python 3, based on existing patches from other forks (listed below) in addition to my own work. Compatibility with Python 2.7 has been preserved for the sake of regression testing, but will probably be removed in the future. Big thanks to the following forks for their Python 3-related fixes!

- https://github.com/contextual-dev/chdkptp.py
- https://github.com/neogranadina/chdkptp.py
- https://github.com/fabrykato/chdkptp.py

This PR also modifies the setup.py so that the 'download/patch/compile chdkptp' steps are run in the 'build' stage instead of being split between the 'install' stage and the main script. This fixes installation with recent versions of pip and should make it easier to build wheels properly in the future.

Additionally, this PR bumps the minimum lupa version to 2.1, which allows us to specify explicitly which Lua version to use (5.2 in this case) instead of relying on the system version (which may be 5.3 or 5.4). Unfortunately the current pre-compiled lupa binaries on PyPi don't support loading shared libraries, but it's easy and relatively fast enough to build lupa and its bundled Lua versions from source using pip:

```bash
# For Python 3.x
LUPA_WITH_LUA_DLOPEN=true pip install --no-binary lupa lupa
# For Python 2.7
LUPA_WITH_LUA_DLOPEN=true pip install lupa==2.2
```

Note that Python 3 support has only been partially tested, due to other issues with parts of the code that need fixing first. However, I was able to run the test.py script successfully up until the DNG capture test, with JPG capture and mode switching working as expected!