### PR TITLE
Fix and export PTPError

### DIFF
--- a/chdkptp/__init__.py
+++ b/chdkptp/__init__.py
@@ -1,4 +1,4 @@
-from chdkptp.device import ChdkDevice, list_devices, DeviceInfo
+from chdkptp.device import ChdkDevice, list_devices, DeviceInfo, PTPError
 
 __version__ = "0.1.3"
-__all__ = ['ChdkDevice', 'list_devices', 'DeviceInfo']
+__all__ = ['ChdkDevice', 'list_devices', 'DeviceInfo', 'PTPError']

--- a/chdkptp/lua.py
+++ b/chdkptp/lua.py
@@ -13,13 +13,13 @@ logger = logging.getLogger('chdkptp.lua')
 
 class PTPError(Exception):
     def __init__(self, err_table):
-        msg = err_table.get('message')
-        errcode = err_table.get('ptp_rc')
+        msg = err_table['msg']
+        errcode = err_table['ptp_rc']
         super(PTPError, self).__init__(
             "{0} (ptp_code: {1})".format(msg or "Unknown error",
                                          errcode or 'unknown'))
         self.ptp_code = errcode
-        self.traceback = err_table.get('traceback')
+        self.traceback = err_table['traceback']
 
 
 class LuaContext(object):


### PR DESCRIPTION
Applies the PTPError fixes helpfully created by @meelash in the following fork: https://github.com/meelash/chdkptp.py

Prior to this, any time a PTPError was generated it would instantly fail due to the 'message' field not existing.